### PR TITLE
fix: package Id is loaded as null when use groupby Id

### DIFF
--- a/src/inc/commons/mysqldb.php
+++ b/src/inc/commons/mysqldb.php
@@ -98,6 +98,9 @@ class MySqlDb
 				$k = $r[$i];
 				$kt = $t[$i];
 				$val = $list[strtolower($k)];
+				if ($val == null) {
+					$val = $list[$k];
+				}
 				if($kt=="object"){
 					$item->$k = unserialize($val);
 				}else if($kt=="number" && $val!=null){


### PR DESCRIPTION
There was a case sensitive problem, when use `groupby  Id` the
application generate a select SQL statement including the same
case style for the column as you write in `groupby`. That can be solved
by two ways: 1) try to build groupby using lower case field names
and  2) when we parse the sql result to entity object test
if `$val = $list[strtolower($k)];` is null, if is null try to get
`$val = $list[$k];`

Closes #2